### PR TITLE
Skip Bazel code in non-macOS bundles.

### DIFF
--- a/Sources/InjectionBazel/BazelAQueryParser.swift
+++ b/Sources/InjectionBazel/BazelAQueryParser.swift
@@ -7,10 +7,6 @@
 
 #if DEBUG || !SWIFT_PACKAGE
 import Foundation
-#if canImport(InjectionImpl)
-import InjectionImpl
-import DLKitD
-#endif
 #if canImport(PopenD)
 import PopenD
 #else
@@ -19,7 +15,8 @@ import Popen
 
 extension String {
     public var unescape: String {
-        return self[#"\\(.)"#, "$1"]
+        return self.replacingOccurrences(of: #"\\(.)"#, with: "$1",
+                                         options: .regularExpression)
     }
 }
 
@@ -28,6 +25,12 @@ public protocol LiteParser {
                found: inout (logDir: String, scanner: Popen?)?) -> String?
   func prepareFinalCommand(command: String, source: String, objectFile: String, tmpdir: String, injectionNumber: Int) -> String
 }
+
+#if os(macOS)
+#if canImport(InjectionImpl)
+import InjectionImpl
+import DLKitD
+#endif
 
 public class BazelAQueryParser: LiteParser {
     private let workspaceRoot: String
@@ -661,4 +664,5 @@ public class BazelAQueryParser: LiteParser {
     
     
 }
+#endif
 #endif

--- a/Sources/InjectionBazel/BazelActionQueryHandler.swift
+++ b/Sources/InjectionBazel/BazelActionQueryHandler.swift
@@ -5,7 +5,7 @@
 //  Handles Bazel AQuery operations for extracting Swift compilation commands
 //
 
-#if DEBUG || !SWIFT_PACKAGE
+#if (DEBUG || !SWIFT_PACKAGE) && os(macOS)
 import Foundation
 #if canImport(InjectionImpl)
 import InjectionImpl

--- a/Sources/InjectionBazel/BazelInterface.swift
+++ b/Sources/InjectionBazel/BazelInterface.swift
@@ -5,7 +5,7 @@
 //  Bazel build system interface for hot reloading support
 //
 
-#if DEBUG || !SWIFT_PACKAGE
+#if (DEBUG || !SWIFT_PACKAGE) && os(macOS)
 import Foundation
 #if canImport(InjectionImpl)
 import InjectionImpl

--- a/Sources/InjectionLite/Recompiler.swift
+++ b/Sources/InjectionLite/Recompiler.swift
@@ -39,6 +39,7 @@ public struct Recompiler {
     }
   
     func findParser(forProjectContaining source: String) -> LiteParser {
+        #if os(macOS)
         // Check if this is a Bazel workspace
         if let workspaceRoot = BazelInterface.findWorkspaceRoot(containing: source) {
             do {
@@ -47,6 +48,7 @@ public struct Recompiler {
                 log("⚠️ Failed to create BazelAQueryParser: \(error), falling back to LogParser")
             }
         }
+        #endif
         
         // Fallback to traditional Xcode log parsing
         return LogParser()


### PR DESCRIPTION
Hi @karim-alweheshy, back from my break now. Is this OK with you since the Bazel code doesn't work in the simulators.