### PR TITLE
Fix Xcode version consistency between compilation and linking

### DIFF
--- a/Sources/InjectionBazel/BazelAQueryParser.swift
+++ b/Sources/InjectionBazel/BazelAQueryParser.swift
@@ -279,9 +279,9 @@ public class BazelAQueryParser: LiteParser {
             }
         }
         
-        // Replace __BAZEL_XCODE_DEVELOPER_DIR__ with actual developer directory  
+        // Replace __BAZEL_XCODE_DEVELOPER_DIR__ with actual developer directory
         if result.contains("__BAZEL_XCODE_DEVELOPER_DIR__") {
-            let developerDir = "/Applications/Xcode.app/Contents/Developer"
+            let developerDir = BinaryResolver.shared.resolveXcodeDeveloperDir()
             result = result.replacingOccurrences(of: "__BAZEL_XCODE_DEVELOPER_DIR__", with: developerDir)
         }
         


### PR DESCRIPTION
## Summary

Ensures both compilation and linking use the same Xcode Developer directory by implementing a consistent resolution strategy across the codebase.

## Problem

Currently, compilation and linking may use different Xcode versions because:
- Compilation resolves Xcode paths through `__BAZEL_XCODE_DEVELOPER_DIR__` placeholder with hardcoded fallback
- Linking extracts paths from compile commands or uses hardcoded defaults
- Neither respected `DEVELOPER_DIR` environment variable or `xcode-select` configuration

This causes build failures for users with multiple Xcode installations.

## Solution

Implemented centralized Xcode Developer directory resolution with consistent priority:

1. `DEVELOPER_DIR` environment variable
2. `xcode-select -p` output  
3. Fallback to `/Applications/Xcode.app/Contents/Developer`

## Changes

- **BinaryResolver**: Added `resolveXcodeDeveloperDir()` method with multi-level fallback logic
- **BazelAQueryParser**: Updated `__BAZEL_XCODE_DEVELOPER_DIR__` resolution to use centralized method
- **Recompiler**: Added Xcode Developer directory resolution at start of `link()` function to ensure consistency

## Test Plan

- [x] Syntax validation with `swiftc -parse` passed
- [ ] Test with `DEVELOPER_DIR` set to specific Xcode version
- [ ] Test with `xcode-select` pointed to specific Xcode version
- [ ] Verify both compilation and linking use same Xcode version in logs