### PR TITLE
Add INJECTION_METRICS_NOTIFICATION constant

### DIFF
--- a/Sources/InjectionImplC/include/InjectionImplC.h
+++ b/Sources/InjectionImplC/include/InjectionImplC.h
@@ -40,6 +40,9 @@
 /// IP or hostname of developer's machine for connecting from device.
 #define INJECTION_HOST "INJECTION_HOST"
 
+/// Notification posted with injection timing metrics.
+#define INJECTION_METRICS_NOTIFICATION "INJECTION_METRICS_NOTIFICATION"
+
 @interface NSObject(InjectionBoot)
 + (BOOL)InjectionBoot_inPreview;
 + (void)runXCTestCase:(Class)aTestCase;


### PR DESCRIPTION
## Summary

Define the `INJECTION_METRICS_NOTIFICATION` constant to centralize the notification name used for injection timing metrics.

## Changes

Added one constant to `InjectionImplC.h`:
- `INJECTION_METRICS_NOTIFICATION` - Notification name posted with injection timing metrics

## Motivation

This constant provides a centralized definition for the metrics notification name, allowing it to be referenced from both C/Objective-C and Swift code.

## Related

Required by johnno1962/InjectionNext#100 which adds injection timing metrics support.