### PR TITLE
Bazel/rules_xcodeproj path fixes, command cleanup, and Recompiler lifecycle hook

### DIFF
--- a/Sources/InjectionBazel/BazelAQueryParser.swift
+++ b/Sources/InjectionBazel/BazelAQueryParser.swift
@@ -115,19 +115,225 @@ public class BazelAQueryParser: LiteParser {
         return optimizedCommand
     }
     
+    /// Bazel output base, resolved lazily from the workspace `bazel-out` symlink.
+    /// In Bazel 7+/Bzlmod the layout is:
+    ///   <outputBase>/execroot/_main/bazel-out/...   (build artifacts)
+    ///   <outputBase>/external/...                   (external repos)
+    private lazy var bazelOutputBase: String = {
+        let bazelOutLink = "\(workspaceRoot)/bazel-out"
+        if let resolved = try? FileManager.default.destinationOfSymbolicLink(atPath: bazelOutLink) {
+            let url = URL(fileURLWithPath: resolved)
+            return url.deletingLastPathComponent()
+                       .deletingLastPathComponent()
+                       .deletingLastPathComponent().path
+        }
+        return workspaceRoot
+    }()
+
+    private lazy var execRoot: String = {
+        let bazelOutLink = "\(workspaceRoot)/bazel-out"
+        if let resolved = try? FileManager.default.destinationOfSymbolicLink(atPath: bazelOutLink) {
+            let url = URL(fileURLWithPath: resolved)
+            return url.deletingLastPathComponent().path
+        }
+        return workspaceRoot
+    }()
+
+    // MARK: - rules_xcodeproj Support
+
+    /// Detects whether rules_xcodeproj is in use and resolves the alternative
+    /// output base where Xcode-triggered builds actually place artifacts.
+    private lazy var rulesXcodeprojExecRoot: String? = {
+        let rxpOutputBase = bazelOutputBase + "/rules_xcodeproj.noindex/build_output_base"
+        let rxpExecRoot = rxpOutputBase + "/execroot/_main"
+        guard FileManager.default.fileExists(atPath: rxpExecRoot) else {
+            return nil
+        }
+        log("📦 Detected rules_xcodeproj output base at: \(rxpOutputBase)")
+        return rxpExecRoot
+    }()
+
+    private lazy var rulesXcodeprojOutputBase: String? = {
+        guard rulesXcodeprojExecRoot != nil else { return nil }
+        return bazelOutputBase + "/rules_xcodeproj.noindex/build_output_base"
+    }()
+
+    /// Cache of aquery config → rules_xcodeproj config directory mappings.
+    /// e.g. "ios_sim_arm64-fastbuild-ST-abc123" → "ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-xyz789"
+    private var configMappingCache = [String: String]()
+
+    /// Maps an aquery configuration directory name to the corresponding
+    /// directory in the rules_xcodeproj output base.
+    ///
+    /// Config format: `<arch>-<mode>[-exec]-<suffix>-ST-<hash>`
+    /// e.g. aquery target:  `ios_sim_arm64-fastbuild-ios-sim_arm64-min17.0-ST-538543d366db`
+    ///      rxp target:     `ios_sim_arm64-dbg-ios-sim_arm64-min17.0-ST-37293c460a5a`
+    ///      aquery exec:    `darwin_arm64-opt-exec-ST-d57f47055a04`
+    ///      rxp exec:       `darwin_arm64-opt-exec-ST-d57f47055a04`  (often identical hash)
+    private func resolveRxpConfig(for aqueryConfig: String) -> String? {
+        if let cached = configMappingCache[aqueryConfig] {
+            return cached
+        }
+        guard let rxpExecRoot = rulesXcodeprojExecRoot else { return nil }
+        let rxpBazelOut = rxpExecRoot + "/bazel-out"
+
+        guard let entries = try? FileManager.default
+                .contentsOfDirectory(atPath: rxpBazelOut) else { return nil }
+
+        // 1) Exact match (exec configs often share the same hash)
+        if entries.contains(aqueryConfig) {
+            log("🔗 Exact match for aquery config '\(aqueryConfig)' in rxp")
+            configMappingCache[aqueryConfig] = aqueryConfig
+            return aqueryConfig
+        }
+
+        let (archPrefix, modeQualifier) = extractArchAndMode(from: aqueryConfig)
+
+        // 2) Match by arch + mode qualifier (e.g. darwin_arm64 + opt-exec)
+        let candidates = entries
+            .filter {
+                let (entryArch, entryMode) = extractArchAndMode(from: $0)
+                return entryArch == archPrefix && entryMode == modeQualifier
+            }
+            .sorted { $0 > $1 }
+
+        if let match = candidates.first {
+            log("🔗 Mapped aquery config '\(aqueryConfig)' → rxp config '\(match)' (mode: \(modeQualifier))")
+            configMappingCache[aqueryConfig] = match
+            return match
+        }
+
+        // 3) For target configs (fastbuild), fall back to dbg with same arch
+        if modeQualifier == "fastbuild" {
+            let dbgCandidates = entries
+                .filter {
+                    let (entryArch, entryMode) = extractArchAndMode(from: $0)
+                    return entryArch == archPrefix && entryMode == "dbg"
+                }
+                .sorted { $0 > $1 }
+
+            if let match = dbgCandidates.first {
+                log("🔗 Mapped aquery config '\(aqueryConfig)' → rxp config '\(match)' (fastbuild→dbg)")
+                configMappingCache[aqueryConfig] = match
+                return match
+            }
+        }
+
+        // 4) Last resort: any config with the same arch prefix
+        let anyMatch = entries
+            .filter { extractArchAndMode(from: $0).arch == archPrefix }
+            .sorted { $0 > $1 }
+            .first
+
+        if let match = anyMatch {
+            log("⚠️ Loose match for '\(aqueryConfig)' → rxp config '\(match)'")
+            configMappingCache[aqueryConfig] = match
+            return match
+        }
+
+        log("⚠️ No rules_xcodeproj config matching '\(aqueryConfig)' in \(rxpBazelOut)")
+        return nil
+    }
+
+    /// Extracts the architecture prefix and mode qualifier from a Bazel config.
+    /// e.g. `ios_sim_arm64-fastbuild-...` → (`ios_sim_arm64`, `fastbuild`)
+    ///      `darwin_arm64-opt-exec-ST-...` → (`darwin_arm64`, `opt-exec`)
+    ///      `darwin_arm64-dbg-ST-...` → (`darwin_arm64`, `dbg`)
+    private func extractArchAndMode(from config: String) -> (arch: String, mode: String) {
+        // Order matters: check compound modes first
+        let modeTokens = ["-fastbuild-", "-opt-exec-", "-dbg-", "-opt-"]
+        let modeNames  = ["fastbuild",   "opt-exec",   "dbg",   "opt"]
+        for (token, mode) in zip(modeTokens, modeNames) {
+            if let range = config.range(of: token) {
+                return (String(config[config.startIndex..<range.lowerBound]), mode)
+            }
+        }
+        return (config.components(separatedBy: "-").first ?? config, "unknown")
+    }
+
+    /// Distinct filesystem spellings of the main workspace execroot (`…/execroot/_main`),
+    /// so absolute paths in aquery output match even with symlink / normalization drift.
+    private func mainExecRootPathVariants() -> [String] {
+        let outputBaseExec = bazelOutputBase + "/execroot/_main"
+        var roots = Set<String>()
+        roots.insert(execRoot)
+        roots.insert(outputBaseExec)
+        roots.insert((execRoot as NSString).standardizingPath)
+        roots.insert((outputBaseExec as NSString).standardizingPath)
+        roots.insert(URL(fileURLWithPath: execRoot).resolvingSymlinksInPath().path)
+        roots.insert(URL(fileURLWithPath: outputBaseExec).resolvingSymlinksInPath().path)
+        return roots.filter { !$0.isEmpty }
+    }
+
+    /// Rewrites all `bazel-out/<config>/` path segments in a command so they
+    /// point to the rules_xcodeproj output base with the correct config hash.
+    ///
+    /// aquery lines use the default output base (`fastbuild`, etc.). Xcode-driven
+    /// rules_xcodeproj builds use `…/rules_xcodeproj.noindex/build_output_base/`.
+    /// When paths are **absolute** (`…/execroot/_main/bazel-out/<cfg>/…`), replacing
+    /// only the `bazel-out/<cfg>/` fragment would splice the rxp execroot onto the
+    /// main execroot and break module map resolution — so longer absolute prefixes
+    /// are rewritten first, then relative `bazel-out/` segments.
+    private func rewritePathsForRulesXcodeproj(_ command: String) -> String {
+        guard let rxpExecRoot = rulesXcodeprojExecRoot else { return command }
+
+        var result = command
+        let pattern = #"bazel-out/([^/]+)/"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return command }
+
+        let nsRange = NSRange(result.startIndex..., in: result)
+        var configsSeen = Set<String>()
+        for match in regex.matches(in: result, range: nsRange) {
+            if let range = Range(match.range(at: 1), in: result) {
+                configsSeen.insert(String(result[range]))
+            }
+        }
+
+        for aqueryConfig in configsSeen {
+            guard let rxpConfig = resolveRxpConfig(for: aqueryConfig) else { continue }
+            let destination = "\(rxpExecRoot)/bazel-out/\(rxpConfig)/"
+
+            // 1) Absolute: …/execroot/_main/bazel-out/<aquery>/  (several spellings)
+            for execVariant in mainExecRootPathVariants() {
+                let oldAbs = "\(execVariant)/bazel-out/\(aqueryConfig)/"
+                result = result.replacingOccurrences(of: oldAbs, with: destination)
+            }
+
+            // 2) Relative to exec root (no directory prefix before bazel-out/)
+            result = result.replacingOccurrences(
+                of: "bazel-out/\(aqueryConfig)/",
+                with: destination)
+        }
+
+        return result
+    }
+
     public func prepareFinalCommand(command: String, source: String, objectFile: String, tmpdir: String, injectionNumber: Int) -> String {
+        let effectiveRoot = rulesXcodeprojExecRoot ?? execRoot
+        let cdPrefix = "cd '\(effectiveRoot)' && "
+
+        // Strip any existing -o flag so we can set our own output path
+        var cmd = command
+        if let regex = try? NSRegularExpression(pattern: #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#, options: []) {
+            let range = NSRange(cmd.startIndex..., in: cmd)
+            cmd = regex.stringByReplacingMatches(in: cmd, options: [], range: range, withTemplate: "")
+        }
+
+        // Replace -emit-object with -c so -o controls output path
+        cmd = cmd.replacingOccurrences(of: " -emit-object", with: " -c")
+
         // Check if this is a frontend command (already optimized)
-        if command.contains("swiftc -frontend") {
-            return command + " -o \(objectFile)"
+        if cmd.contains("swiftc -frontend") {
+            return cdPrefix + cmd + " -o \(objectFile)"
         }
         
         // For non-frontend commands, try output-file-map first
         let outputFileMapRegex = #" -output-file-map ([^\s\\]*(?:\\.[^\s\\]*)*)"#
-        if let outputFileMapPath = (command[outputFileMapRegex] as String?)?.unescape {
-            return createMinimalOutputFileMapCommand(command: command, source: source, objectFile: objectFile, outputFileMapPath: outputFileMapPath, tmpdir: tmpdir, injectionNumber: injectionNumber)
+        if let outputFileMapPath = (cmd[outputFileMapRegex] as String?)?.unescape {
+            return createMinimalOutputFileMapCommand(command: cmd, source: source, objectFile: objectFile, outputFileMapPath: outputFileMapPath, tmpdir: tmpdir, injectionNumber: injectionNumber)
         } else {
             // Traditional -o flag fallback
-            return command + " -o \(objectFile)"
+            return cmd + " -o \(objectFile)"
         }
     }
     
@@ -164,6 +370,13 @@ public class BazelAQueryParser: LiteParser {
         // Remove output-file-map since frontend mode will use -o instead
         let outputFileMapRegex = #" -output-file-map ([^\s\\]*(?:\\.[^\s\\]*)*)"#
         if let regex = try? NSRegularExpression(pattern: outputFileMapRegex, options: []) {
+            let range = NSRange(cleanedCommand.startIndex..., in: cleanedCommand)
+            cleanedCommand = regex.stringByReplacingMatches(in: cleanedCommand, options: [], range: range, withTemplate: "")
+        }
+
+        // Remove existing -o flags so prepareFinalCommand can set the correct output path
+        let existingOutputRegex = #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
+        if let regex = try? NSRegularExpression(pattern: existingOutputRegex, options: []) {
             let range = NSRange(cleanedCommand.startIndex..., in: cleanedCommand)
             cleanedCommand = regex.stringByReplacingMatches(in: cleanedCommand, options: [], range: range, withTemplate: "")
         }
@@ -210,6 +423,13 @@ public class BazelAQueryParser: LiteParser {
     private func cleanBazelCommand(_ command: String) -> String {
         var cleanedCommand = command
         
+        // Strip Bazel worker binary prefix: the aquery command starts with
+        // something like "/path/to/worker swiftc ..." — the worker binary
+        // uses a protobuf stdin protocol and can't be invoked directly.
+        if let workerRange = cleanedCommand.range(of: #"[^\s]*worker\s+"#, options: .regularExpression) {
+            cleanedCommand.removeSubrange(cleanedCommand.startIndex..<workerRange.upperBound)
+        }
+        
         // Remove Bazel-specific flags that interfere with hot reloading
         let flagsToRemove = [
             "-const-gather-protocols-file",
@@ -220,6 +440,18 @@ public class BazelAQueryParser: LiteParser {
             "-module-cache-path",
             "-num-threads"
         ]
+        
+        // WMO prevents single-file recompilation — the compiler silently
+        // skips -primary-file / -emit-object when WMO is active.
+        let standaloneFlags = [
+            "-whole-module-optimization",
+            "-internalize-at-link",
+            "-no-serialize-debugging-options",
+        ]
+        for flag in standaloneFlags {
+            cleanedCommand = cleanedCommand.replacingOccurrences(
+                of: flag, with: "")
+        }
         
         // Also remove -Xwrapped-swift flags which have a different pattern
         let xWrappedSwiftPattern = "\\s+'-Xwrapped-swift=[^']*'"
@@ -235,6 +467,61 @@ public class BazelAQueryParser: LiteParser {
             cleanedCommand = regex.stringByReplacingMatches(in: cleanedCommand, options: [], range: range, withTemplate: "")
         }
         
+        // Strip -Xfrontend wrapper since we invoke swift-frontend directly.
+        // The Bazel aquery command is already in frontend mode, so -Xfrontend
+        // is redundant and causes "unknown argument" errors.
+        while cleanedCommand.contains(" -Xfrontend ") {
+            cleanedCommand = cleanedCommand.replacingOccurrences(of: " -Xfrontend ", with: " ")
+        }
+        
+        // Strip the `cd "<execRoot>" &&` prefix that BazelActionQueryHandler
+        // embeds — prepareFinalCommand will add the correct one.
+        if let cdRange = cleanedCommand.range(
+            of: #"^cd \"[^\"]+\" && "#, options: .regularExpression) {
+            cleanedCommand.removeSubrange(cdRange)
+        }
+
+        // When rules_xcodeproj is in use, rewrite bazel-out/<config>/ paths
+        // to the correct output base with the matching config hash FIRST,
+        // before doing generic relative→absolute resolution.
+        cleanedCommand = rewritePathsForRulesXcodeproj(cleanedCommand)
+
+        // Choose the correct output base / execroot for external/ and bazel-out/
+        // resolution. For rules_xcodeproj, artifacts live in a separate output base.
+        let effectiveOutputBase = rulesXcodeprojOutputBase ?? bazelOutputBase
+        let effectiveExecRoot = rulesXcodeprojExecRoot ?? execRoot
+
+        // In Bazel 7+/Bzlmod, external repos live at <outputBase>/external/,
+        // NOT at <execroot>/_main/external/. Replace relative external/ refs
+        // with the absolute path so the compiler can find module maps and
+        // headers for third-party dependencies.
+        let absExternal = "\(effectiveOutputBase)/external/"
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: "=external/", with: "=\(absExternal)")
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: " external/", with: " \(absExternal)")
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: "'external/", with: "'\(absExternal)")
+
+        // bazel-out/ relative paths must also be resolved to absolute.
+        // After rewritePathsForRulesXcodeproj, any remaining bazel-out/ refs
+        // are ones that didn't match a config (or rules_xcodeproj isn't in use).
+        let absBazelOut = "\(effectiveExecRoot)/bazel-out/"
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: "=bazel-out/", with: "=\(absBazelOut)")
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: " bazel-out/", with: " \(absBazelOut)")
+        cleanedCommand = cleanedCommand.replacingOccurrences(
+            of: "'bazel-out/", with: "'\(absBazelOut)")
+
+        // Flags that concatenate the path directly (no space before the relative path)
+        for prefix in ["-F", "-I", "-iquote", "-isystem"] {
+            cleanedCommand = cleanedCommand.replacingOccurrences(
+                of: "\(prefix)external/", with: "\(prefix)\(absExternal)")
+            cleanedCommand = cleanedCommand.replacingOccurrences(
+                of: "\(prefix)bazel-out/", with: "\(prefix)\(absBazelOut)")
+        }
+
         // Replace Bazel placeholders in the command with actual values
         let finalCommand = replaceBazelPlaceholders(in: cleanedCommand)
         
@@ -460,13 +747,17 @@ public class BazelAQueryParser: LiteParser {
         // Split command into components, handling quoted arguments
         let components = parseCommandComponents(command)
         
-        // Find Swift files (ending with .swift) but ignore flags starting with dash
+        let pathArgFlags: Set<String> = ["-F", "-I", "-iquote", "-isystem", "-Xcc"]
+        var previousComponent = ""
         for component in components {
             let cleanPath = component.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-            
-            if cleanPath.hasSuffix(".swift") && !cleanPath.hasPrefix("-") {
+            let cleanPrev = previousComponent.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+
+            if cleanPath.hasSuffix(".swift") && !cleanPath.hasPrefix("-")
+                && !pathArgFlags.contains(cleanPrev) {
                 swiftFiles.append(cleanPath)
             }
+            previousComponent = component
         }
         
         // Filter out the changed file to create list of other files
@@ -588,13 +879,13 @@ public class BazelAQueryParser: LiteParser {
         
         // Step 2: Remove all .swift files from the command
         for swiftFile in allFiles {
-            // Handle both quoted and unquoted file paths
-            let quotedFile = "\"\(swiftFile)\""
+            let escaped = NSRegularExpression.escapedPattern(for: swiftFile)
+            let doubleQuoted = NSRegularExpression.escapedPattern(for: "\"\(swiftFile)\"")
+            let singleQuoted = NSRegularExpression.escapedPattern(for: "'\(swiftFile)'")
             let patterns = [
-                " \(swiftFile)(?=\\s|$)",
-                " \(quotedFile)(?=\\s|$)",
-                "\\s+\(NSRegularExpression.escapedPattern(for: swiftFile))(?=\\s|$)",
-                "\\s+\(NSRegularExpression.escapedPattern(for: quotedFile))(?=\\s|$)"
+                "\\s+\(singleQuoted)(?=\\s|$)",
+                "\\s+\(doubleQuoted)(?=\\s|$)",
+                "\\s+\(escaped)(?=\\s|$)",
             ]
             
             for pattern in patterns {
@@ -606,7 +897,8 @@ public class BazelAQueryParser: LiteParser {
         }
         
         // Step 3: Add -primary-file with the changed file
-        transformedCommand += " -primary-file \(primaryFile)"
+        let quotedPrimary = primaryFile.contains(" ") ? "'\(primaryFile)'" : primaryFile
+        transformedCommand += " -primary-file \(quotedPrimary)"
 
         // Step 4: Add plugin paths for system macros
 
@@ -621,7 +913,8 @@ public class BazelAQueryParser: LiteParser {
 
         // Step 5: Add other Swift files as secondary sources (using cleaned list)
         for otherFile in cleanOtherFiles {
-            transformedCommand += " \(otherFile)"  
+            let quoted = otherFile.contains(" ") ? "'\(otherFile)'" : otherFile
+            transformedCommand += " \(quoted)"
         }
         
         return transformedCommand
@@ -634,28 +927,28 @@ public class BazelAQueryParser: LiteParser {
         
         var adjustedCommand = command
         
-        // Find and replace existing -primary-file argument
-        let primaryFilePattern = #" -primary-file ([^\s\\]*(?:\\.[^\s\\]*)*)"#
+        // Find and replace existing -primary-file argument (handles unquoted, single-quoted, and double-quoted paths)
+        let primaryFilePattern = #" -primary-file (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
         if let regex = try? NSRegularExpression(pattern: primaryFilePattern, options: []) {
             let range = NSRange(adjustedCommand.startIndex..., in: adjustedCommand)
             let matches = regex.matches(in: adjustedCommand, options: [], range: range)
             
             if let match = matches.first, let matchRange = Range(match.range, in: adjustedCommand) {
-                // Replace the entire -primary-file argument
                 let oldPrimaryFile = String(adjustedCommand[matchRange])
-                adjustedCommand = adjustedCommand.replacingOccurrences(of: oldPrimaryFile, with: " -primary-file \(newPrimaryFile)")
+                let quotedNew = newPrimaryFile.contains(" ") ? "'\(newPrimaryFile)'" : newPrimaryFile
+                adjustedCommand = adjustedCommand.replacingOccurrences(of: oldPrimaryFile, with: " -primary-file \(quotedNew)")
                 log("🔄 Replaced primary file in existing frontend command")
                 log("   Old: \(oldPrimaryFile)")
                 log("   New: -primary-file \(URL(fileURLWithPath: newPrimaryFile).lastPathComponent)")
             }
         } else {
-            // If no -primary-file found, add it
-            adjustedCommand += " -primary-file \(newPrimaryFile)"
+            let quotedNew = newPrimaryFile.contains(" ") ? "'\(newPrimaryFile)'" : newPrimaryFile
+            adjustedCommand += " -primary-file \(quotedNew)"
             log("➕ Added -primary-file to existing frontend command")
         }
         
-        // Remove existing -o flag since prepareFinalCommand will add the correct one
-        let outputPattern = #" -o ([^\s\\]*(?:\\.[^\s\\]*)*)"#
+        // Remove existing -o flag since prepareFinalCommand will add the correct one (handles quoted paths)
+        let outputPattern = #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
         if let regex = try? NSRegularExpression(pattern: outputPattern, options: []) {
             let range = NSRange(adjustedCommand.startIndex..., in: adjustedCommand)
             let matches = regex.matches(in: adjustedCommand, options: [], range: range)

--- a/Sources/InjectionBazel/BazelAQueryParser.swift
+++ b/Sources/InjectionBazel/BazelAQueryParser.swift
@@ -314,7 +314,7 @@ public class BazelAQueryParser: LiteParser {
 
         // Strip any existing -o flag so we can set our own output path
         var cmd = command
-        if let regex = try? NSRegularExpression(pattern: #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#, options: []) {
+        if let regex = try? NSRegularExpression(pattern: Reloader.compilerOutputFlagRegex, options: []) {
             let range = NSRange(cmd.startIndex..., in: cmd)
             cmd = regex.stringByReplacingMatches(in: cmd, options: [], range: range, withTemplate: "")
         }
@@ -375,7 +375,7 @@ public class BazelAQueryParser: LiteParser {
         }
 
         // Remove existing -o flags so prepareFinalCommand can set the correct output path
-        let existingOutputRegex = #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
+        let existingOutputRegex = Reloader.compilerOutputFlagRegex
         if let regex = try? NSRegularExpression(pattern: existingOutputRegex, options: []) {
             let range = NSRange(cleanedCommand.startIndex..., in: cleanedCommand)
             cleanedCommand = regex.stringByReplacingMatches(in: cleanedCommand, options: [], range: range, withTemplate: "")
@@ -928,7 +928,7 @@ public class BazelAQueryParser: LiteParser {
         var adjustedCommand = command
         
         // Find and replace existing -primary-file argument (handles unquoted, single-quoted, and double-quoted paths)
-        let primaryFilePattern = #" -primary-file (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
+        let primaryFilePattern = Reloader.primaryFileFlagRegex
         if let regex = try? NSRegularExpression(pattern: primaryFilePattern, options: []) {
             let range = NSRange(adjustedCommand.startIndex..., in: adjustedCommand)
             let matches = regex.matches(in: adjustedCommand, options: [], range: range)
@@ -948,7 +948,7 @@ public class BazelAQueryParser: LiteParser {
         }
         
         // Remove existing -o flag since prepareFinalCommand will add the correct one (handles quoted paths)
-        let outputPattern = #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#
+        let outputPattern = Reloader.compilerOutputFlagRegex
         if let regex = try? NSRegularExpression(pattern: outputPattern, options: []) {
             let range = NSRange(adjustedCommand.startIndex..., in: adjustedCommand)
             let matches = regex.matches(in: adjustedCommand, options: [], range: range)

--- a/Sources/InjectionImpl/Common.swift
+++ b/Sources/InjectionImpl/Common.swift
@@ -85,6 +85,12 @@ extension Reloader {
 
     /// Regex for path argument, perhaps containg escaped spaces
     public static let argumentRegex = #"[^\s\\]*(?:\\.[^\s\\]*)*"#
+    /// Single-quoted, double-quoted, or unquoted shell token (backslash-escaped); extends `argumentRegex`.
+    public static let quotedArgumentRegex = #"(?:'[^']*'|"[^"]*"|\#(argumentRegex))"#
+    /// ` -o <path>` for stripping a prior compiler output before reinjection sets its own `-o`.
+    public static let compilerOutputFlagRegex = " -o " + quotedArgumentRegex
+    /// ` -primary-file <path>` with the same quoting rules as `-o`.
+    public static let primaryFileFlagRegex = " -primary-file " + quotedArgumentRegex
     /// Regex to extract filename base, perhaps containg escaped spaces
     public static let fileNameRegex = #"/(\#(argumentRegex))\.\w+"#
     /// Parse -sdk argument to extract sdk, Xcode path, platform

--- a/Sources/InjectionLite/LogParser.swift
+++ b/Sources/InjectionLite/LogParser.swift
@@ -155,7 +155,7 @@ struct LogParser: LiteParser {
     func prepareFinalCommand(command: String, source: String, objectFile: String, tmpdir: String, injectionNumber: Int) -> String {
         var cmd = command
         cmd = cmd.replacingOccurrences(of: " -emit-object", with: " -c")
-        if let regex = try? NSRegularExpression(pattern: #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#, options: []) {
+        if let regex = try? NSRegularExpression(pattern: Reloader.compilerOutputFlagRegex, options: []) {
             let range = NSRange(cmd.startIndex..., in: cmd)
             cmd = regex.stringByReplacingMatches(in: cmd, options: [], range: range, withTemplate: "")
         }

--- a/Sources/InjectionLite/LogParser.swift
+++ b/Sources/InjectionLite/LogParser.swift
@@ -153,7 +153,13 @@ struct LogParser: LiteParser {
     }
 
     func prepareFinalCommand(command: String, source: String, objectFile: String, tmpdir: String, injectionNumber: Int) -> String {
-        command + " -o \(objectFile)"
+        var cmd = command
+        cmd = cmd.replacingOccurrences(of: " -emit-object", with: " -c")
+        if let regex = try? NSRegularExpression(pattern: #" -o (?:'[^']*'|"[^"]*"|[^\s\\]*(?:\\.[^\s\\]*)*)"#, options: []) {
+            let range = NSRange(cmd.startIndex..., in: cmd)
+            cmd = regex.stringByReplacingMatches(in: cmd, options: [], range: range, withTemplate: "")
+        }
+        return cmd + " -o \(objectFile)"
     }
 }
 #endif

--- a/Sources/InjectionLite/Recompiler.swift
+++ b/Sources/InjectionLite/Recompiler.swift
@@ -27,6 +27,9 @@ import Popen
 
 public struct Recompiler {
 
+    /// Host app hook for progress (e.g. MCP): basename, status (`compiling` / `compiled` / `failed`), optional detail.
+    public static var onCompilationEvent: ((_ file: String, _ status: String, _ detail: String?) -> Void)?
+
     /// A cache is kept of compiltaion commands in /tmp as Xcode housekeeps logs.
     lazy var longTermCache = NSMutableDictionary(contentsOfFile:
                     Reloader.cacheFile) ?? NSMutableDictionary()
@@ -112,6 +115,7 @@ public struct Recompiler {
 
         let fileName = URL(fileURLWithPath: source).lastPathComponent
         log("🔄 [\(fileName)] Recompiling\(platformFilter.isEmpty ? "" : " (\(platformFilter))")")
+        Self.onCompilationEvent?(fileName, "compiling", nil)
 
         Reloader.injectionNumber += 1
         let objectFile = tmpbase + ".o"
@@ -155,12 +159,15 @@ public struct Recompiler {
             log("Processing command: "+finalCommand+"\n")
             log("Current log: \(FileWatcher.derivedLog ?? "no log")")
             log("❌ Compilation failed:\n"+errors)
+            Self.onCompilationEvent?(fileName, "failed", "compilation error")
             return nil
         }
 
         // Log successful compilation with timing
         let compilationDuration = Date.timeIntervalSinceReferenceDate - compilationStartTime
         log(String(format: "⚡ Compiled in %.0fms", compilationDuration * 1000))
+        Self.onCompilationEvent?(fileName, "compiled",
+            String(format: "%.0fms", compilationDuration * 1000))
 
         if let frameworksArg: String = command[
             " -F (\(Reloader.argumentRegex)/PackageFrameworks) "] {

--- a/Sources/InjectionLite/Recompiler.swift
+++ b/Sources/InjectionLite/Recompiler.swift
@@ -13,17 +13,12 @@
 //
 
 #if DEBUG || !SWIFT_PACKAGE
-#if canImport(InjectionImplC)
-import InjectionImplC
-import InjectionBazel
-import InjectionImpl
+#if canImport(InjectionImpl)
+@_exported import InjectionBazel
+@_exported import InjectionImplC
+@_exported import InjectionImpl
 #endif
 import Foundation
-#if canImport(PopenD)
-import PopenD
-#else
-import Popen
-#endif
 
 public struct Recompiler {
 
@@ -70,10 +65,11 @@ public struct Recompiler {
         var scanned: (logDir: String, scanner: Popen?)?
         let cacheKey = source+platformFilter
         self.cacheKey = cacheKey
-        var cachedCommand = longTermCache[cacheKey] as? String
+        var cachedCommand = getenv("NO_CACHING") == nil ?
+            longTermCache[cacheKey] as? String : nil
         if cachedCommand?.contains("llvmcas://") == true {
-            log("⚠️ Injection is not compatable with build " +
-                "setting COMPILATION_CACHE_ENABLE_CACHING")
+            log("⚠️ Injection is not compatable with build" +
+                " setting COMPILATION_CACHE_ENABLE_CACHING")
             writeToCache(removing: cacheKey)
             cachedCommand = nil
         }
@@ -118,10 +114,16 @@ public struct Recompiler {
         Self.onCompilationEvent?(fileName, "compiling", nil)
 
         Reloader.injectionNumber += 1
-        let objectFile = tmpbase + ".o"
+        var objectFile = tmpbase + ".o"
         unlink(objectFile)
         let benchmark = source.hasSuffix(".swift") ? Reloader.typeCheckLimit : ""
-        let finalCommand = parser.prepareFinalCommand(
+        var builtinSwitftCompile = 0
+        withUnsafeMutablePointer(to: &builtinSwitftCompile) {
+            command[LogParser.builtinSwiftCompile, count: $0] = ""
+        }
+        let finalCommand = builtinSwitftCompile != 0 ?
+            command[#"-use-frontend-parseable-output "#, ""]+" -Xfrontend \(benchmark)" :
+            parser.prepareFinalCommand(
             command: command,
             source: source,
             objectFile: objectFile,
@@ -150,9 +152,8 @@ public struct Recompiler {
 
 //            if !errors.contains(" error: ") { break }
             if !errors.contains("error: ") { break }
-            let wasCached = longTermCache[cacheKey] != nil
             writeToCache(removing: cacheKey)
-            if wasCached { // retry once
+            if cachedCommand != nil { // retry once
                 return recompile(source: source, platformFilter:
                                     platformFilter, dylink: dylink)
             }
@@ -176,7 +177,37 @@ public struct Recompiler {
         }
         if longTermCache[cacheKey] as? String != command {
             longTermCache[cacheKey] = command
-            writeToCache()
+            if builtinSwitftCompile == 0 {
+                writeToCache()
+            }
+        }
+
+        if builtinSwitftCompile != 0 {
+            log("""
+                ℹ️ Falling back to "builtin" compilation of files. \
+                This only works injecting files in the main package. \
+                Injection is faster if you add a build setting to \
+                your project: \(EMIT_FRONTEND_COMMAND_LINES)=YES \
+                then restart the \(APP_NAME) app.
+                """)
+            var located = false, filename = URL(fileURLWithPath: source)
+                .deletingPathExtension().lastPathComponent+".o"
+            for base in FileWatcher.objectBases {
+                let candidate = URL(fileURLWithPath: base)
+                    .appendingPathComponent(filename).path
+                if FileManager.default.fileExists(atPath: candidate) {
+                    print(APP_PREFIX+"Located object file "+candidate)
+                    objectFile = candidate[#"([ $()])"#, "\\\\$1"]
+                    located = true
+                    break
+                }
+            }
+            if !located {
+                log("⚠️ Valid object path not found. Modify a file and build." +
+                    " Add a build setting \(EMIT_FRONTEND_COMMAND_LINES)=YES.")
+                writeToCache(removing: source)
+                return nil
+            }
         }
 
         Reloader.extractLinkCommand(from: finalCommand)

--- a/Sources/InjectionLite/Recompiler.swift
+++ b/Sources/InjectionLite/Recompiler.swift
@@ -13,12 +13,17 @@
 //
 
 #if DEBUG || !SWIFT_PACKAGE
-#if canImport(InjectionImpl)
-@_exported import InjectionBazel
-@_exported import InjectionImplC
-@_exported import InjectionImpl
+#if canImport(InjectionImplC)
+import InjectionImplC
+import InjectionBazel
+import InjectionImpl
 #endif
 import Foundation
+#if canImport(PopenD)
+import PopenD
+#else
+import Popen
+#endif
 
 public struct Recompiler {
 
@@ -62,11 +67,10 @@ public struct Recompiler {
         var scanned: (logDir: String, scanner: Popen?)?
         let cacheKey = source+platformFilter
         self.cacheKey = cacheKey
-        var cachedCommand = getenv("NO_CACHING") == nil ?
-            longTermCache[cacheKey] as? String : nil
+        var cachedCommand = longTermCache[cacheKey] as? String
         if cachedCommand?.contains("llvmcas://") == true {
-            log("⚠️ Injection is not compatable with build" +
-                " setting COMPILATION_CACHE_ENABLE_CACHING")
+            log("⚠️ Injection is not compatable with build " +
+                "setting COMPILATION_CACHE_ENABLE_CACHING")
             writeToCache(removing: cacheKey)
             cachedCommand = nil
         }
@@ -110,16 +114,10 @@ public struct Recompiler {
         log("🔄 [\(fileName)] Recompiling\(platformFilter.isEmpty ? "" : " (\(platformFilter))")")
 
         Reloader.injectionNumber += 1
-        var objectFile = tmpbase + ".o"
+        let objectFile = tmpbase + ".o"
         unlink(objectFile)
         let benchmark = source.hasSuffix(".swift") ? Reloader.typeCheckLimit : ""
-        var builtinSwitftCompile = 0
-        withUnsafeMutablePointer(to: &builtinSwitftCompile) {
-            command[LogParser.builtinSwiftCompile, count: $0] = ""
-        }
-        let finalCommand = builtinSwitftCompile != 0 ?
-            command[#"-use-frontend-parseable-output "#, ""]+" -Xfrontend \(benchmark)" :
-            parser.prepareFinalCommand(
+        let finalCommand = parser.prepareFinalCommand(
             command: command,
             source: source,
             objectFile: objectFile,
@@ -148,8 +146,9 @@ public struct Recompiler {
 
 //            if !errors.contains(" error: ") { break }
             if !errors.contains("error: ") { break }
+            let wasCached = longTermCache[cacheKey] != nil
             writeToCache(removing: cacheKey)
-            if cachedCommand != nil { // retry once
+            if wasCached { // retry once
                 return recompile(source: source, platformFilter:
                                     platformFilter, dylink: dylink)
             }
@@ -170,37 +169,7 @@ public struct Recompiler {
         }
         if longTermCache[cacheKey] as? String != command {
             longTermCache[cacheKey] = command
-            if builtinSwitftCompile == 0 {
-                writeToCache()
-            }
-        }
-
-        if builtinSwitftCompile != 0 {
-            log("""
-                ℹ️ Falling back to "builtin" compilation of files. \
-                This only works injecting files in the main package. \
-                Injection is faster if you add a build setting to \
-                your project: \(EMIT_FRONTEND_COMMAND_LINES)=YES \
-                then restart the \(APP_NAME) app.
-                """)
-            var located = false, filename = URL(fileURLWithPath: source)
-                .deletingPathExtension().lastPathComponent+".o"
-            for base in FileWatcher.objectBases {
-                let candidate = URL(fileURLWithPath: base)
-                    .appendingPathComponent(filename).path
-                if FileManager.default.fileExists(atPath: candidate) {
-                    print(APP_PREFIX+"Located object file "+candidate)
-                    objectFile = candidate[#"([ $()])"#, "\\\\$1"]
-                    located = true
-                    break
-                }
-            }
-            if !located {
-                log("⚠️ Valid object path not found. Modify a file and build." +
-                    " Add a build setting \(EMIT_FRONTEND_COMMAND_LINES)=YES.")
-                writeToCache(removing: source)
-                return nil
-            }
+            writeToCache()
         }
 
         Reloader.extractLinkCommand(from: finalCommand)


### PR DESCRIPTION
## Summary

This branch brings **InjectionLite** in line with modern Bazel layouts (Bazel 7+ / Bzlmod), **rules_xcodeproj**’s separate output base, and safer reuse of aquery-derived compile lines. On **`Recompiler`**, the only behavioral addition is an **optional host hook** (`onCompilationEvent`) so apps (e.g. InjectionNext + MCP) can observe log-parser/Bazel recompile progress without coupling to a specific UI — the rest of **`Recompiler` stays aligned with upstream** (`@_exported` imports, `NO_CACHING`, builtin Swift fallback, and original retry logic).

---

## 1. `BazelAQueryParser` — Bazel 7 / Bzlmod & rules_xcodeproj

- **Output base & execroot:** Resolve `bazelOutputBase` and `execRoot` from the workspace `bazel-out` symlink (Bazel 7+ `execroot/_main` layout).
- **rules_xcodeproj:** Detect `…/rules_xcodeproj.noindex/build_output_base` and use its `execroot/_main` when present.
- **Config mapping:** Map aquery config directory names (e.g. `fastbuild`) to the corresponding directory under the rules_xcodeproj `bazel-out` (exact match, arch+mode, `fastbuild`→`dbg` fallback, loose arch match) with caching.
- **Path rewrite:** `rewritePathsForRulesXcodeproj` rewrites `bazel-out/<config>/` segments so absolute `…/execroot/_main/bazel-out/…` paths are not incorrectly spliced with the wrong execroot (fixes module map / header resolution when Xcode-driven builds use a different hash).
- **Command cleaning:**
  - Strip **Bazel worker** binary prefix (worker speaks protobuf on stdin; cannot be run as a plain shell command).
  - Remove **WMO** flags that prevent single-file / `-primary-file` behavior.
  - Strip redundant **`-Xfrontend`** when invoking the frontend directly.
  - Remove embedded **`cd "…" &&`** from aquery text; **`prepareFinalCommand`** prepends `cd '<effectiveExecRoot>' &&` using rules_xcodeproj execroot when applicable.
- **Third-party paths:** Resolve relative `external/` and `bazel-out/` to **`<outputBase>/external/`** and **`<execroot>/bazel-out/`**, including `-F`/`-I`/`-iquote`/`-isystem`/`-Xcc` forms.
- **Output & frontend flags:** Strip existing **`-o`** (including quoted paths), replace **`-emit-object`** with **`-c`**, so reinjection always controls the object path.
- **Swift file detection:** Do not treat `.swift` paths after **`-F` / `-I` / `-iquote` / `-isystem` / `-Xcc`** as source inputs (avoids picking up SDK paths that end in `.swift`).
- **Quoted paths:** More robust removal of per-file Swift args and **`-primary-file`** / **`-o`** handling for quoted paths; quote primary/secondary files when paths contain spaces.

---

## 2. `LogParser` — align with Bazel command shape

- **`prepareFinalCommand`:** Replace **`-emit-object`** with **`-c`**, strip any existing **`-o`**, then append **`-o <injection object>`** (same idea as the Bazel parser’s output handling).

---

## 3. `Recompiler` — upstream parity + `onCompilationEvent` only

- **Baseline:** Matches upstream **`Recompiler`** (e.g. `johnno1962/InjectionLite`): **`@_exported import`** InjectionImpl stack, **`NO_CACHING`** gate for the long-term cache, **builtin Swift** path with **`prepareFinalCommand` vs.** stripped frontend + **`-Xfrontend`**, object discovery under **`FileWatcher.objectBases`**, and **retry once** when **`cachedCommand != nil`** after a failed compile.
- **`onCompilationEvent`:** Single additive API — `public static var` closure **`(file, status, detail?)`**. Emits **`compiling`** after the recompile log line, **`compiled`** with detail **`"Nms"`** after a successful compile, **`failed`** with **`"compilation error"`** when compilation errors out. Host apps (e.g. InjectionNext) can forward this to **`InjectionEventTracker`** / MCP without changing compile or cache behavior.

---

## Testing / notes

- Validated against **rules_xcodeproj** workflows where aquery paths pointed at the default output base but Xcode artifacts lived under `rules_xcodeproj.noindex/build_output_base`.
- **`onCompilationEvent`** is optional (`nil` by default); unset keeps upstream behavior.

---

## Risk / follow-ups

- **rules_xcodeproj** config heuristics may need tuning for unusual configuration naming if new Bazel/Xcodeproj layouts appear.
