### PR TITLE
Fix SwiftPM build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .target(
             name: "InjectionImpl",
             dependencies: ["InjectionImplC",
+                .product(name: "PopenD", package: "Popen"),
                 .product(name: "DLKitD", package: "DLKit"), // DEBUG_ONLY versions
                 .product(name: "SwiftRegexD", package: "SwiftRegex")]),
         // Boots up standalone injection on load for InjectionLite product

--- a/Sources/InjectionImpl/Unhider.swift
+++ b/Sources/InjectionImpl/Unhider.swift
@@ -10,6 +10,8 @@
 //  This code exports these symbols in all object files in the derived data
 //  of a project so code which uses a default argument is able to inject.
 //
+
+#if DEBUG || !SWIFT_PACKAGE
 import Foundation
 #if SWIFT_PACKAGE
 import DLKitD
@@ -141,3 +143,4 @@ open class Unhider {
         return patched
     }
 }
+#endif


### PR DESCRIPTION
Building `InjectionImpl` with SwiftPM currently fails because of two issues. This PR fixes them.

1. The target imports PopenD but doesn't depend on it. It just so happens that `InjectionLite` adds the dependency, so it gets transitively included when building the larger module, but if you clean and build `InjectionImpl` by itself it doesn't work. Fixed by adding an explicit dependency.
2. `Unhider.swift` doesn't include the same debug guards as the other files so release builds fail. Fixed by adding the debug guards to this file.