### PR TITLE
feat(spm): expose InjectionBazel as a public product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,12 @@ let package = Package(
             name: "InjectionImpl",
             dependencies: ["InjectionImplC",
                 .product(name: "PopenD", package: "Popen"),
+                // Also declare the non-debug Popen — Xcode 26's dep
+                // scanner reads ALL #if branches in source files; some
+                // branches `import Popen` (without D), and without this
+                // dep declared the scanner emits a (mislabeled?) warning
+                // about a missing PopenD dependency.
+                .product(name: "Popen", package: "Popen"),
                 .product(name: "DLKitD", package: "DLKit"), // DEBUG_ONLY versions
                 .product(name: "SwiftRegexD", package: "SwiftRegex")]),
         // Boots up standalone injection on load for InjectionLite product

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,13 @@ let package = Package(
         .library(
             name: "InjectionImpl",
             targets: ["InjectionImpl"]),
+        // Expose InjectionBazel so embedders can flip `BazelInterface.isDisabled`
+        // at startup to skip the Bazel workspace probe when they're not
+        // using Bazel — avoids the spurious "Failed to create BazelAQueryParser"
+        // log line on every save.
+        .library(
+            name: "InjectionBazel",
+            targets: ["InjectionBazel"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.


### PR DESCRIPTION
## Why

Two fixes for downstream consumers on Xcode 26 / Swift 6:

### 1. Expose `InjectionBazel` as a public product

Currently `InjectionBazel` is an internal target. Downstream consumers
can't `import InjectionBazel` to flip `BazelInterface.isDisabled = true`,
so on every save InjectionLite probes for a Bazel workspace, fails, and
logs:

```
🔥 ⚠️ Failed to create BazelAQueryParser: ..., falling back to LogParser
```

The probe failure is the *intended* fallback path (`Recompiler.findParser`
correctly falls through to LogParser), but the warning is alarming and
shows up on every recompile. `BazelInterface.isDisabled` already exists
in `BazelInterface.swift` for exactly this case — just no way for
embedders to reach it without forking.

### 2. Add `Popen` (non-debug variant) to `InjectionImpl` deps

`Sources/InjectionImpl/Unhider.swift` has `import Popen` in its
`#elseif INJECTION_NEXT_APP` and `#else` branches. Xcode 26's strict
dep-scanner parses all branches and emits a (slightly mislabeled)
warning about a missing `PopenD` dep on every cold build:

```
warning: 'InjectionImpl' is missing a dependency on 'PopenD' because dependency scan of Swift module 'InjectionImpl' discovered a dependency on 'PopenD'
```

Adding the `Popen` product to the `InjectionImpl` deps alongside the
existing `PopenD` silences the scanner.

## Changes

Two-line manifest change. No source touched.

```diff
 .target(
     name: "InjectionImpl",
     dependencies: ["InjectionImplC",
         .product(name: "PopenD", package: "Popen"),
+        .product(name: "Popen", package: "Popen"),
         .product(name: "DLKitD", package: "DLKit"),
         .product(name: "SwiftRegexD", package: "SwiftRegex")]),
```

```diff
+.library(
+    name: "InjectionBazel",
+    targets: ["InjectionBazel"]),
```

## Compatibility

- No source changes.
- Existing consumers (who only import `InjectionLite`) are unaffected — both products are pulled in transitively.
- `InjectionBazel` export is opt-in; nothing changes unless someone imports it.

Tested locally on Xcode 26.1.1 / macOS 26.5 in a SwiftPM-based macOS app built via `xcodebuild`. Cold and incremental builds now produce zero warnings. Hot reload continues to work.