### PR TITLE
Use git check-ignore for ignored source files

### DIFF
--- a/Sources/InjectionBazel/GitIgnoreParser.swift
+++ b/Sources/InjectionBazel/GitIgnoreParser.swift
@@ -6,6 +6,13 @@
 //
 
 import Foundation
+#if os(macOS)
+#if canImport(PopenD)
+import PopenD
+#else
+import Popen
+#endif
+#endif
 
 /// Wrapper class for FilenameMatcher to use with NSCache
 private final class MatcherWrapper {
@@ -20,7 +27,8 @@ private final class MatcherWrapper {
 public final class GitIgnoreParser {
     private static let matcherCache = NSCache<NSString, MatcherWrapper>()
     private static let ignoreCache = NSCache<NSString, NSNumber>()
-    private static var gitIgnoreParsers: [GitIgnoreParser] = []
+    private static let monitoredDirectoriesLock = NSLock()
+    private static var monitoredDirectories: [String] = []
     private var patterns: [GitIgnorePattern] = []
     
     struct GitIgnorePattern {
@@ -118,9 +126,9 @@ public final class GitIgnoreParser {
         
         for pattern in patterns {
             guard let matcher = pattern.matcher else { continue }
-            
+
             var matches = false
-            
+
             if pattern.isDirectory {
                 // For directory patterns like "build/", match:
                 // - The directory itself: "build" or "build/"
@@ -166,37 +174,64 @@ public final class GitIgnoreParser {
     }
 
     public static func monitor(directory: String) {
-        let parsers = GitIgnoreParser.findGitIgnoreFiles(startingFrom: directory)
-        Self.gitIgnoreParsers.append(contentsOf: parsers)
+        let monitoredDirectory = URL(fileURLWithPath: directory)
+            .standardizedFileURL.path
+
+        monitoredDirectoriesLock.lock()
+        defer { monitoredDirectoriesLock.unlock() }
+
+        guard !monitoredDirectories.contains(monitoredDirectory) else { return }
+        monitoredDirectories.append(monitoredDirectory)
+        monitoredDirectories.sort { $0.count > $1.count }
     }
 
     static public func shouldExclude(file filePath: String) -> String? {
-        // Early exit: Only process relevant source files
-        guard isValidSourceFile(filePath) else {
-            return "not a valid source file"
+        return shouldExclude(files: [filePath])[filePath]
+    }
+
+    static public func shouldExclude(files filePaths: [String]) -> [String: String] {
+        var exclusions: [String: String] = [:]
+        var filesToCheck: [String] = []
+
+        for filePath in filePaths {
+            // Early exit: Only process relevant source files
+            guard isValidSourceFile(filePath) else {
+                exclusions[filePath] = "not a valid source file"
+                continue
+            }
+
+            // Use cached result if available
+            if let cachedResult = ignoreCache.object(forKey: filePath as NSString) {
+                if cachedResult.boolValue {
+                    exclusions[filePath] = "gitignore rule"
+                }
+                continue
+            }
+
+            filesToCheck.append(filePath)
         }
-        
-        // Use cached result if available
-        if let cachedResult = ignoreCache.object(forKey: filePath as NSString) {
-            return cachedResult.boolValue ? "gitignore rule" : nil
-        }
-        
-        // Check if file should be ignored according to gitignore rules
-        var isDirectory: ObjCBool = false
-        FileManager.default.fileExists(atPath: filePath, isDirectory: &isDirectory)
-        var shouldIgnore = false
-        
-        for parser in gitIgnoreParsers {
-            if parser.shouldIgnore(path: filePath, isDirectory: isDirectory.boolValue) {
-                shouldIgnore = true
-                break
+
+        let filesByDirectory = Dictionary(grouping: filesToCheck,
+                                          by: gitCheckDirectory(for:))
+        for (directory, files) in filesByDirectory {
+            guard let ignoredFiles = gitCheckIgnore(filePaths: files, in: directory) else {
+                for file in files {
+                    ignoreCache.setObject(NSNumber(value: false),
+                                          forKey: file as NSString)
+                }
+                continue
+            }
+            for file in files {
+                let shouldIgnore = ignoredFiles.contains(file)
+                ignoreCache.setObject(NSNumber(value: shouldIgnore),
+                                      forKey: file as NSString)
+                if shouldIgnore {
+                    exclusions[file] = "gitignore rule"
+                }
             }
         }
-        
-        // Cache the result - NSCache handles memory management automatically
-        ignoreCache.setObject(NSNumber(value: shouldIgnore), forKey: filePath as NSString)
-        
-        return shouldIgnore ? "gitignore rule" : nil
+
+        return exclusions
     }
 
     public static var  validExtensions = Set([
@@ -209,5 +244,58 @@ public final class GitIgnoreParser {
         }
         let fileExtension = "." + pathExtension
         return validExtensions.contains(fileExtension)
+    }
+
+#if os(macOS)
+    private static func gitCheckIgnore(filePaths: [String], in directory: String) -> Set<String>? {
+        guard !filePaths.isEmpty else { return [] }
+
+        let inputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InjectionLiteCheckIgnore-\(UUID().uuidString)")
+        let input = filePaths.joined(separator: "\n") + "\n"
+        do {
+            try input.write(to: inputURL, atomically: true, encoding: .utf8)
+        } catch {
+            return nil
+        }
+        defer { try? FileManager.default.removeItem(at: inputURL) }
+
+        let gitProcess = Topen(exec: "/bin/bash",
+                               arguments: [
+                                   "-c",
+                                   #"exec /usr/bin/git -C "$1" check-ignore --stdin < "$2""#,
+                                   "git-check-ignore",
+                                   directory,
+                                   inputURL.path
+                               ],
+                               cd: directory)
+        let output = Set(gitProcess)
+        _ = gitProcess.terminatedOK()
+        guard gitProcess.exitStatus == EXIT_SUCCESS || gitProcess.exitStatus == 1 else {
+            return nil
+        }
+
+        return output
+    }
+#else
+    private static func gitCheckIgnore(filePaths: [String], in directory: String) -> Set<String>? {
+        return nil
+    }
+#endif
+
+    private static func gitCheckDirectory(for filePath: String) -> String {
+        let standardizedPath = URL(fileURLWithPath: filePath).standardizedFileURL.path
+
+        monitoredDirectoriesLock.lock()
+        let directories = monitoredDirectories
+        monitoredDirectoriesLock.unlock()
+
+        if let monitoredDirectory = directories.first(where: {
+            standardizedPath == $0 || standardizedPath.hasPrefix($0 + "/")
+        }) {
+            return monitoredDirectory
+        }
+
+        return (filePath as NSString).deletingLastPathComponent
     }
 }

--- a/Tests/InjectionLiteTests/GitIgnoreTests.swift
+++ b/Tests/InjectionLiteTests/GitIgnoreTests.swift
@@ -138,5 +138,140 @@ final class GitIgnoreTests: XCTestCase {
         XCTAssertFalse(parser.shouldIgnore(path: "main.swift"))
         XCTAssertFalse(parser.shouldIgnore(path: ".bazel-other-file.swift")) // Edge case: .bazel- prefix but not matching pattern
     }
+
+    func testShouldExcludeUsesGitCheckIgnore() throws {
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: "/usr/bin/git"))
+
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InjectionLiteGitIgnoreTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try withIsolatedGitEnvironment(at: repo) {
+            try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+            try runGit(["init"], in: repo)
+            try "/.tmp\n".write(to: repo.appendingPathComponent(".gitignore"),
+                                atomically: true,
+                                encoding: .utf8)
+
+            let ignoredSource = repo
+                .appendingPathComponent(".tmp/bazel_output_base/external/foo.cpp")
+            try FileManager.default.createDirectory(at: ignoredSource.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try "int main() { return 0; }\n".write(to: ignoredSource,
+                                                   atomically: true,
+                                                   encoding: .utf8)
+
+            let trackedSource = repo
+                .appendingPathComponent("Sources/App/ViewController.swift")
+            try FileManager.default.createDirectory(at: trackedSource.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try "struct ViewController {}\n".write(to: trackedSource,
+                                                   atomically: true,
+                                                   encoding: .utf8)
+
+            XCTAssertEqual(GitIgnoreParser.shouldExclude(file: ignoredSource.path), "gitignore rule")
+            XCTAssertNil(GitIgnoreParser.shouldExclude(file: trackedSource.path))
+        }
+    }
+
+    func testShouldExcludeFilesBatchesGitCheckIgnore() throws {
+        try XCTSkipUnless(FileManager.default.isExecutableFile(atPath: "/usr/bin/git"))
+
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InjectionLiteGitIgnoreBatchTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try withIsolatedGitEnvironment(at: repo) {
+            try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+            try runGit(["init"], in: repo)
+            try "/.tmp\n*.generated.swift\n".write(to: repo.appendingPathComponent(".gitignore"),
+                                                   atomically: true,
+                                                   encoding: .utf8)
+            GitIgnoreParser.monitor(directory: repo.path)
+
+            let ignoredCpp = repo
+                .appendingPathComponent(".tmp/bazel_output_base/external/foo.cpp")
+            let ignoredSwift = repo
+                .appendingPathComponent("Sources/App/View.generated.swift")
+            let trackedSwift = repo
+                .appendingPathComponent("Sources/App/View.swift")
+            for source in [ignoredCpp, ignoredSwift, trackedSwift] {
+                try FileManager.default.createDirectory(at: source.deletingLastPathComponent(),
+                                                        withIntermediateDirectories: true)
+                try "source\n".write(to: source, atomically: true, encoding: .utf8)
+            }
+
+            let exclusions = GitIgnoreParser.shouldExclude(files: [
+                ignoredCpp.path,
+                ignoredSwift.path,
+                trackedSwift.path
+            ])
+
+            XCTAssertEqual(exclusions[ignoredCpp.path], "gitignore rule")
+            XCTAssertEqual(exclusions[ignoredSwift.path], "gitignore rule")
+            XCTAssertNil(exclusions[trackedSwift.path])
+        }
+    }
+
+    private func withIsolatedGitEnvironment(at repo: URL, _ body: () throws -> Void) throws {
+        let environment = ProcessInfo.processInfo.environment
+        let keys = ["HOME", "XDG_CONFIG_HOME", "GIT_CONFIG_NOSYSTEM"]
+        let previousValues = keys.reduce(into: [String: String]()) { values, key in
+            values[key] = environment[key]
+        }
+        defer {
+            for key in keys {
+                if let previousValue = previousValues[key] {
+                    setenv(key, previousValue, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+
+        setenv("HOME", repo.path, 1)
+        setenv("XDG_CONFIG_HOME", repo.appendingPathComponent(".config").path, 1)
+        setenv("GIT_CONFIG_NOSYSTEM", "1", 1)
+        try body()
+    }
+
+    private func runGit(_ arguments: [String], in directory: URL) throws {
+        let process = Process()
+        let outputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        let readOutput = readPipeInBackground(outputPipe)
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0,
+                       "git \(arguments.joined(separator: " ")) failed:\n\(readOutput())")
+    }
+
+    private func readPipeInBackground(_ pipe: Pipe) -> () -> String {
+        final class OutputBox {
+            var data = Data()
+        }
+
+        let box = OutputBox()
+        let group = DispatchGroup()
+        group.enter()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                group.leave()
+            } else {
+                box.data.append(data)
+            }
+        }
+
+        return {
+            group.wait()
+            return String(data: box.data, encoding: .utf8) ?? ""
+        }
+    }
     
 }


### PR DESCRIPTION
## Summary

- Use `git check-ignore` as the source-file exclusion decision in `shouldExclude`.
- Add `shouldExclude(files:)` so callers can batch a file-event group through one `git check-ignore --stdin` process per watched repository root.
- Cache both ignored and non-ignored results by full path so repeated file events stay in-process.
- Keep the parser itself for direct `shouldIgnore` callers/tests, while `monitor` now records watched roots for efficient grouping.
- Add regression coverage for `/.tmp` ignoring Bazel output under `.tmp/bazel_output_base/.../*.cpp`, plus a batch-path test.

## Validation

- `git diff --check`
- `swift build --target InjectionBazel`
- `swift test --filter GitIgnoreTests.testShouldExcludeUsesGitCheckIgnore`
- `swift test --filter GitIgnoreTests.testShouldExcludeFilesBatchesGitCheckIgnore`
- Addressed Copilot review by caching failed Git checks as non-excluded and draining test helper output for diagnostics.
- Built `InjectionNext.app` with the package change and validated pending-file batching against a Bazel workspace containing generated C++ files beneath a root-ignored `/.tmp` directory; the generated files were excluded as expected.

## Performance

The batch API collapses a group of uncached file events into one `git check-ignore --stdin` invocation instead of spawning one process per path. This PR makes no application-level performance claim.

Note: the full `GitIgnoreTests` class currently has an existing upstream parser expectation failure around `/build/`; this PR intentionally moves the runtime exclusion path to Git instead of changing parser semantics.

